### PR TITLE
Add tests for copying. Setup project for pytest.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 1. Clone the repo and make a new branch: `$ git checkout https://github.com/alichtman/shallow-backup -b [name_of_new_branch]`.
 2. Make changes and test them.
-3. Run unit tests and make sure all tests pass: `python -m unittest`.
+3. Run unit tests and make sure all tests pass: `python -m pytest`.
 4. Update README, if necessary.
 5. Update CONTRIBUTORS.md
 6. Open a Pull Request with a comprehensive description of changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@
 
 1. Clone the repo and make a new branch: `$ git checkout https://github.com/alichtman/shallow-backup -b [name_of_new_branch]`.
 2. Make changes and test them.
-3. Update README, if necessary.
-4. Update CONTRIBUTORS.md
-5. Open a Pull Request with a comprehensive description of changes
+3. Run unit tests and make sure all tests pass: `python -m unittest`.
+4. Update README, if necessary.
+5. Update CONTRIBUTORS.md
+6. Open a Pull Request with a comprehensive description of changes
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 
 - [Caleb Jasik](https://github.com/jasikpark)
 - [Moritz Schillinger](https://github.com/schilli91)
+- [Peter Yasi](https://github.com/pyasi)

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ click = "*"
 inquirer = "*"
 gitpython = "*"
 colorama = "*"
+pytest = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ click = "*"
 inquirer = "*"
 gitpython = "*"
 colorama = "*"
-pytest = "*"
 
 [dev-packages]
 

--- a/constants.py
+++ b/constants.py
@@ -7,3 +7,5 @@ class Constants:
 	URL='https://github.com/alichtman/shallow-backup'
 	AUTHOR_EMAIL='aaronlichtman@gmail.com'
 	CONFIG_PATH='.shallow-backup'
+	INVALIDS = [".Trash", ".npm", ".cache", ".rvm"]
+

--- a/constants.py
+++ b/constants.py
@@ -7,5 +7,5 @@ class Constants:
 	URL='https://github.com/alichtman/shallow-backup'
 	AUTHOR_EMAIL='aaronlichtman@gmail.com'
 	CONFIG_PATH='.shallow-backup'
-	INVALIDS = [".Trash", ".npm", ".cache", ".rvm"]
+	INVALID_DIRS = [".Trash", ".npm", ".cache", ".rvm"]
 

--- a/shallow_backup.py
+++ b/shallow_backup.py
@@ -121,7 +121,7 @@ def copy_dir(source_dir, backup_path):
 	"""
 	Copy dotfolder from $HOME.
 	"""
-	invalid = {".Trash", ".npm", ".cache", ".rvm"}
+	invalid = set(Constants.INVALIDS)
 	if len(invalid.intersection(set(source_dir.split("/")))) != 0:
 		return
 

--- a/shallow_backup.py
+++ b/shallow_backup.py
@@ -132,7 +132,8 @@ def copy_dir(source_dir, backup_path):
 	else:
 		command = "cp -a '" + source_dir + "' '" + backup_path + "/'"
 
-	sp.run(command, shell=True, stdout=sp.PIPE)
+	process = sp.run(command, shell=True, stdout=sp.PIPE)
+	return process
 
 
 def _copy_file(source, target):
@@ -141,7 +142,8 @@ def _copy_file(source, target):
 	"""
 	command = "cp -a '" + source + "' '" + target + "'"
 	# print(command)
-	sp.run(command, shell=True, stdout=sp.PIPE)
+	process = sp.run(command, shell=True, stdout=sp.PIPE)
+	return process
 
 
 def _mkdir_or_pass(dir):

--- a/shallow_backup.py
+++ b/shallow_backup.py
@@ -117,11 +117,11 @@ def backup_prompt():
 	return answers.get('choice').strip().lower()
 
 
-def copy_dir(source_dir, backup_path):
+def _copy_dir(source_dir, backup_path):
 	"""
 	Copy dotfolder from $HOME.
 	"""
-	invalid = set(Constants.INVALIDS)
+	invalid = set(Constants.INVALID_DIRS)
 	if len(invalid.intersection(set(source_dir.split("/")))) != 0:
 		return
 
@@ -211,7 +211,7 @@ def backup_dotfiles(backup_path):
 
 		for x in dotfolders_mp_in:
 			x = list(x)
-			mp.Process(target=copy_dir, args=(x[0], x[1],)).start()
+			mp.Process(target=_copy_dir, args=(x[0], x[1],)).start()
 
 	with mp.Pool(mp.cpu_count()):
 		print(Fore.BLUE + Style.BRIGHT +

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -1,11 +1,11 @@
 import pytest
 import os
 import shutil
-from shallow_backup import _copy_file, copy_dir
+from shallow_backup import _copy_file, _copy_dir
 from constants import Constants
 
-TEST_DIR = 'test-directory'
-TEST_BACKUP_DIR = 'test-backup-dir'
+TEST_DIR = 'shallow-backup-test-dir'
+TEST_BACKUP_DIR = 'shallow-backup-test-backup-dir'
 TEST_TEXT_FILE = 'test-file.txt'
 DIRS = [TEST_DIR, TEST_BACKUP_DIR]
 
@@ -42,17 +42,18 @@ class TestCopyMethods:
         """
         Test that copying a directory works as expected
         """
-        dir_to_copy = '/test/'
-        os.mkdir(TEST_DIR + dir_to_copy)
-        process = copy_dir(TEST_DIR + dir_to_copy, TEST_BACKUP_DIR)
+        test_dir = '/test/'
+        test_path = os.path.join(TEST_DIR + test_dir)
+        os.mkdir(test_path)
+        process = _copy_dir(test_path, TEST_BACKUP_DIR)
         assert process.returncode == 0
-        assert os.path.isdir(TEST_DIR + dir_to_copy)
-        assert os.path.isdir(TEST_BACKUP_DIR + dir_to_copy)
+        assert os.path.isdir(test_path)
+        assert os.path.isdir(os.path.join(TEST_BACKUP_DIR + test_dir))
 
-    @pytest.mark.parametrize('invalid', Constants.INVALIDS)
+    @pytest.mark.parametrize('invalid', Constants.INVALID_DIRS)
     def test_copy_dir_invalid(self, invalid):
         """
         Test that attempting to copy an invalid directory fails
         """
-        process = copy_dir(invalid, TEST_DIR)
+        process = _copy_dir(invalid, TEST_DIR)
         assert process is None

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 import os
 import shutil
 from shallow_backup import _copy_file, copy_dir
@@ -10,12 +10,12 @@ TEST_TEXT_FILE = 'test-file.txt'
 DIRS = [TEST_DIR, TEST_BACKUP_DIR]
 
 
-class TestCopyMethods(unittest.TestCase):
+class TestCopyMethods:
     """
     Test the functionality of copying
     """
 
-    def setUp(self):
+    def setup_method(self):
         for directory in DIRS:
             try:
                 os.mkdir(directory)
@@ -25,7 +25,7 @@ class TestCopyMethods(unittest.TestCase):
         f = open(TEST_TEXT_FILE, "w+")
         f.close()
 
-    def tearDown(self):
+    def teardown_method(self):
         shutil.rmtree(TEST_DIR)
         os.remove(TEST_TEXT_FILE)
 
@@ -49,10 +49,10 @@ class TestCopyMethods(unittest.TestCase):
         assert os.path.isdir(TEST_DIR + dir_to_copy)
         assert os.path.isdir(TEST_BACKUP_DIR + dir_to_copy)
 
-    def test_copy_dir_invalid(self):
+    @pytest.mark.parametrize('invalid', Constants.INVALIDS)
+    def test_copy_dir_invalid(self, invalid):
         """
         Test that attempting to copy an invalid directory fails
         """
-        for invalid in Constants.INVALIDS:
-            process = copy_dir(invalid, TEST_DIR)
-            assert process is None
+        process = copy_dir(invalid, TEST_DIR)
+        assert process is None

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -1,0 +1,58 @@
+import unittest
+import os
+import shutil
+from shallow_backup import _copy_file, copy_dir
+
+TEST_DIR = 'test-directory'
+TEST_BACKUP_DIR = 'test-backup-dir'
+TEST_TEXT_FILE = 'test-file.txt'
+DIRS = [TEST_DIR, TEST_BACKUP_DIR]
+
+
+class TestCopyMethods(unittest.TestCase):
+    """
+    Test the functionality of copying
+    """
+
+    def setUp(self):
+        for directory in DIRS:
+            try:
+                os.mkdir(directory)
+            except FileExistsError:
+                shutil.rmtree(directory)
+                os.mkdir(directory)
+        f = open(TEST_TEXT_FILE, "w+")
+        f.close()
+
+    def tearDown(self):
+        shutil.rmtree(TEST_DIR)
+        os.remove(TEST_TEXT_FILE)
+
+    def test_copy_file(self):
+        """
+        Test that copying a file is working as expected
+        """
+        process =_copy_file(TEST_TEXT_FILE, TEST_DIR)
+        assert process.returncode == 0
+        assert os.path.isfile(TEST_TEXT_FILE)
+        assert os.path.isfile(TEST_DIR + '/' + TEST_TEXT_FILE)
+
+    def test_copy_dir(self):
+        """
+        Test that copying a directory works as expected
+        """
+        dir_to_copy = '/test/'
+        os.mkdir(TEST_DIR + dir_to_copy)
+        process = copy_dir(TEST_DIR + dir_to_copy, TEST_BACKUP_DIR)
+        assert process.returncode == 0
+        assert os.path.isdir(TEST_DIR + dir_to_copy)
+        assert os.path.isdir(TEST_BACKUP_DIR + dir_to_copy)
+
+    def test_copy_dir_invalid(self):
+        """
+        Test that attempting to copy an invalid directory fails
+        """
+        invalids = [".Trash", ".npm", ".cache", ".rvm"]
+        for invalid in invalids:
+            process = copy_dir(invalid, TEST_DIR)
+            assert process is None

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import shutil
 from shallow_backup import _copy_file, copy_dir
+from constants import Constants
 
 TEST_DIR = 'test-directory'
 TEST_BACKUP_DIR = 'test-backup-dir'
@@ -52,7 +53,6 @@ class TestCopyMethods(unittest.TestCase):
         """
         Test that attempting to copy an invalid directory fails
         """
-        invalids = [".Trash", ".npm", ".cache", ".rvm"]
-        for invalid in invalids:
+        for invalid in Constants.INVALIDS:
             process = copy_dir(invalid, TEST_DIR)
             assert process is None


### PR DESCRIPTION
- Added tests for critical paths in the copying functionality
- Made a small refactor to the INVALID dirs to be a constant. Thus they can be referenced anywhere and changed in one place
- Used pytest as requested in https://github.com/alichtman/shallow-backup/issues/69


This is just a start to the testing journey possibilities! But wanted to get my feet wet in the repository.