### PR TITLE
Push to remote URL and git logging added

### DIFF
--- a/shallow_backup.py
+++ b/shallow_backup.py
@@ -593,7 +593,7 @@ def get_default_config():
 	Returns a default configuration.
 	"""
 	return {
-		"backup_path": "DEFAULT",
+		"backup_path": "~/shallow-backup",
 		"dotfiles"   : [
 			".bashrc",
 			".bash_profile",


### PR DESCRIPTION
Bug in `git_set_remote` that has to be fixed before this can be merged.

```python
def git_set_remote(repo, remote_url):
	"""
	Sets git repo upstream URL and fast-forwards history.
	TODO: Allow users to name the remote.
	"""
	print(Fore.GREEN + Style.BRIGHT + "Setting remote URL to {}...".format(remote_url) + Style.RESET_ALL)
	remotes = [remote for remote in repo.remotes]
	# pprint([remote.url for remote in remotes])
	# Repo has no remotes, just create a new remote and pull.
	if len(remotes) == 0:
		origin = create_remote(repo, remote_url)
		if not repo.head:
			repo.create_head('master', origin.refs.master)
		repo.heads.master.set_tracking_branch(origin.refs.master).checkout()
		origin.fetch()
	# Update push URL with new URL.
	else:
		# TODO: Fix this error that fails a push after updating the URL:
		# 		"There is no tracking information for the current branch."
		repo.delete_remote(repo.remotes.origin)
		origin = create_remote(repo, remote_url)
		repo.heads.master.set_tracking_branch(origin.refs.master).checkout()
		origin.fetch()
```