### PR TITLE
Move git folder on path change

### DIFF
--- a/shallow_backup.py
+++ b/shallow_backup.py
@@ -622,7 +622,7 @@ def get_default_config():
 # CLI
 #######
 
-def move_git_folder_to_path(source_path, new_path, made_new_config):
+def move_git_folder_to_path(source_path, new_path):
 	"""
 	Moves git folder and .gitignore to the new backup directory.
 	"""
@@ -632,13 +632,12 @@ def move_git_folder_to_path(source_path, new_path, made_new_config):
 	try:
 		shutil.move(git_dir, new_path)
 		shutil.move(git_ignore_file, new_path)
-		print(Fore.BLUE + "Moving git repo to new destination" + Style.RESET_ALL)
-	except FileNotFoundError as e:
-		if not made_new_config:
-			print(Fore.RED + Style.NORMAL + "Could not detect {}... will initialize".format(e.filename) + Style.RESET_ALL)
+		print(Fore.BLUE + Style.BRIGHT + "Moving git repo to new destination" + Style.RESET_ALL)
+	except FileNotFoundError:
+		pass
 
 
-def prompt_for_path_update(config, made_new_config):
+def prompt_for_path_update(config):
 	"""
 	Ask user if they'd like to update the backup path or not.
 	If yes, update. If no... don't.
@@ -659,7 +658,7 @@ def prompt_for_path_update(config, made_new_config):
 		config["backup_path"] = abs_path
 		write_config(config)
 		make_dir_warn_overwrite(abs_path)
-		move_git_folder_to_path(current_path, abs_path, made_new_config)
+		move_git_folder_to_path(current_path, abs_path)
 
 
 
@@ -702,10 +701,6 @@ def cli(complete, dotfiles, configs, packages, fonts, old_path, new_path, remote
 		print(Fore.BLUE + Style.BRIGHT + "Creating config file at {}".format(backup_config_path))
 		backup_config = get_default_config()
 		write_config(backup_config)
-		made_new_config = True
-	else:
-		made_new_config = False
-
 
 	#####
 	# Update backup path from CLI args, prompt user, or skip updating
@@ -727,7 +722,7 @@ def cli(complete, dotfiles, configs, packages, fonts, old_path, new_path, remote
 		pass
 	# User didn't enter a new path, didn't use the same_path flag or any backup options, so prompt
 	else:
-		prompt_for_path_update(backup_config, made_new_config)
+		prompt_for_path_update(backup_config)
 
 	###
 	# Create backup directory and set up git stuff

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -27,6 +27,7 @@ class TestCopyMethods:
 
     def teardown_method(self):
         shutil.rmtree(DIR_TO_BACKUP)
+        shutil.rmtree(BACKUP_DIR)
         os.remove(TEST_TEXT_FILE)
 
     def test_copy_file(self):
@@ -37,14 +38,14 @@ class TestCopyMethods:
         process =_copy_file(TEST_TEXT_FILE, BACKUP_DIR)
         assert process.returncode == 0
         assert os.path.isfile(TEST_TEXT_FILE)
-        assert os.path.isfile(os.path.join(BACKUP_DIR, TEST_TEXT_FILE)
+        assert os.path.isfile(os.path.join(BACKUP_DIR, TEST_TEXT_FILE))
 
     def test_copy_dir(self):
         """
         Test that copying a directory works as expected
         """
         # TODO: Test that all subfiles and folders are copied.
-        test_dir = 'test'
+        test_dir = 'test/'
         test_path = os.path.join(DIR_TO_BACKUP, test_dir)
         os.mkdir(test_path)
         process = _copy_dir(test_path, BACKUP_DIR)

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -4,8 +4,8 @@ import shutil
 from shallow_backup import _copy_file, _copy_dir
 from constants import Constants
 
-DIR_TO_BACKUP = 'shallow-backup-test-dir'
-BACKUP_DIR = 'shallow-backup-test-backup-dir'
+DIR_TO_BACKUP = 'shallow-backup-test-copy-dir'
+BACKUP_DIR = 'shallow-backup-test-copy-backup-dir'
 TEST_TEXT_FILE = 'test-file.txt'
 DIRS = [DIR_TO_BACKUP, BACKUP_DIR]
 
@@ -26,8 +26,8 @@ class TestCopyMethods:
         f.close()
 
     def teardown_method(self):
-        shutil.rmtree(DIR_TO_BACKUP)
-        shutil.rmtree(BACKUP_DIR)
+        for directory in DIRS:
+            shutil.rmtree(directory)
         os.remove(TEST_TEXT_FILE)
 
     def test_copy_file(self):

--- a/tests/test_git_folder_moving.py
+++ b/tests/test_git_folder_moving.py
@@ -26,6 +26,7 @@ class TestGitFolderCopying:
 
     def test_copy_git_folder(self):
         """
+        Test copying the .git folder and .gitignore from an old directory to a new one
         """
         git_init_if_needed(OLD_BACKUP_DIR)
         create_gitignore_if_needed(OLD_BACKUP_DIR)

--- a/tests/test_git_folder_moving.py
+++ b/tests/test_git_folder_moving.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+from shallow_backup import move_git_folder_to_path, git_init_if_needed, create_gitignore_if_needed
+
+OLD_BACKUP_DIR = 'shallow-backup-test-git-old-backup-dir'
+NEW_BACKUP_DIR = 'shallow-backup-test-git-new-backup-backup-dir'
+DIRS = [OLD_BACKUP_DIR, NEW_BACKUP_DIR]
+
+
+class TestGitFolderCopying:
+    """
+    Test the functionality of .git copying
+    """
+
+    def setup_method(self):
+        for directory in DIRS:
+            try:
+                os.mkdir(directory)
+            except FileExistsError:
+                shutil.rmtree(directory)
+                os.mkdir(directory)
+
+    def teardown_method(self):
+        for directory in DIRS:
+            shutil.rmtree(directory)
+
+    def test_copy_git_folder(self):
+        """
+        """
+        git_init_if_needed(OLD_BACKUP_DIR)
+        create_gitignore_if_needed(OLD_BACKUP_DIR)
+        move_git_folder_to_path(OLD_BACKUP_DIR, NEW_BACKUP_DIR, False)
+        assert os.path.isdir(os.path.join(NEW_BACKUP_DIR, '.git/'))
+        assert os.path.isfile(os.path.join(NEW_BACKUP_DIR, '.gitignore'))
+        assert not os.path.isdir(os.path.join(OLD_BACKUP_DIR, '.git/'))
+        assert not os.path.isfile(os.path.join(OLD_BACKUP_DIR, '.gitignore'))
+


### PR DESCRIPTION
Copy the .git folder and .gitignore file to a new path when creating a new destination path for you backups. 