### PR TITLE
fix bug: path was absolute so os.path.join was discarding the user ho…

### DIFF
--- a/shallow_backup.py
+++ b/shallow_backup.py
@@ -362,7 +362,7 @@ def backup_fonts(path):
 	print_section_header("FONTS", Fore.BLUE)
 	make_dir_warn_overwrite(path)
 	print(Fore.BLUE + "Copying '.otf' and '.ttf' fonts..." + Style.RESET_ALL)
-	fonts_path = _home_prefix("/Library/Fonts/")
+	fonts_path = _home_prefix("Library/Fonts/")
 	# TODO: For some reason, this doesn't get all the fonts in fonts_path dir
 	fonts = [os.path.join(fonts_path, font) for font in os.listdir(fonts_path) if font.endswith(".otf") or font.endswith(".ttf")]
 

--- a/shallow_backup.py
+++ b/shallow_backup.py
@@ -363,12 +363,9 @@ def backup_fonts(path):
 	make_dir_warn_overwrite(path)
 	print(Fore.BLUE + "Copying '.otf' and '.ttf' fonts..." + Style.RESET_ALL)
 	fonts_path = _home_prefix("Library/Fonts/")
-	# TODO: For some reason, this doesn't get all the fonts in fonts_path dir
 	fonts = [os.path.join(fonts_path, font) for font in os.listdir(fonts_path) if font.endswith(".otf") or font.endswith(".ttf")]
 
-	# pprint(fonts)
 	for font in fonts:
-		# print(font, " TO ", os.path.join(path, font.split("/")[-1]))
 		if os.path.exists(font):
 			copyfile(font, os.path.join(path, font.split("/")[-1]))
 


### PR DESCRIPTION
solves #111 
The problem was the fact that the path given to the `_home_prefix` function was absolute. The documentation of the function `os.path.join` (https://docs.python.org/3/library/os.path.html#os.path.join) reads:

> If a component is an absolute path, all previous components are thrown away and joining continues from the absolute path component.