### PR TITLE
Exit if a git repository exists on the new backup path

### DIFF
--- a/shallow_backup/git_wrapper.py
+++ b/shallow_backup/git_wrapper.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import git
 from shutil import move
 from printing import *
@@ -92,6 +93,11 @@ def move_git_repo(source_path, new_path):
 	"""
 	Moves git folder and .gitignore to the new backup directory.
 	"""
+	if os.path.exists(os.path.join(new_path, '.git')) or os.path.exists(os.path.join(new_path, '.gitignore')):
+		print_red_bold("Git repository already exists new path ({})".format(new_path))
+		print_red_bold("Please choose a different directory")
+		sys.exit()
+
 	git_dir = os.path.join(source_path, '.git')
 	git_ignore_file = os.path.join(source_path, '.gitignore')
 

--- a/shallow_backup/git_wrapper.py
+++ b/shallow_backup/git_wrapper.py
@@ -89,23 +89,30 @@ def git_add_all_commit_push(repo, message):
 		print_yellow_bold("No changes to commit...")
 
 
-def move_git_repo(source_path, new_path):
+def move_git_repo(source_path, dest_path):
 	"""
 	Moves git folder and .gitignore to the new backup directory.
+	Exits if there is already a git repo in the directory.
 	"""
-	new_git_dir = os.path.join(new_path, '.git')
-	new_git_ignore = os.path.join(new_path, '.gitignore')
-	if os.path.exists(new_git_dir) or os.path.exists(new_git_ignore):
-		print_red_bold("A git repo already exists here: {}".format(new_path))
-		print_red_bold("Please choose a different backup path.")
+	dest_git_dir = os.path.join(dest_path, '.git')
+	dest_git_ignore = os.path.join(dest_path, '.gitignore')
+	git_exists = os.path.exists(dest_git_dir)
+	gitignore_exists = os.path.exists(dest_git_ignore)
+	if git_exists or gitignore_exists:
+		print_red_bold("Evidence of a git repo has been detected.")
+		if git_exists:
+			print_path_red("A git repo already exists here:", dest_git_dir)
+		if gitignore_exists:
+			print_path_red("A gitignore file already exists here:", dest_git_ignore)
+		print_red_bold("Exiting to prevent accidental deletion of user data.")
 		sys.exit()
 
 	git_dir = os.path.join(source_path, '.git')
 	git_ignore_file = os.path.join(source_path, '.gitignore')
 
 	try:
-		move(git_dir, new_path)
-		move(git_ignore_file, new_path)
+		move(git_dir, dest_path)
+		move(git_ignore_file, dest_path)
 		print_blue_bold("Moving git repo to new location.")
 	except FileNotFoundError:
 		pass

--- a/shallow_backup/git_wrapper.py
+++ b/shallow_backup/git_wrapper.py
@@ -93,7 +93,9 @@ def move_git_repo(source_path, new_path):
 	"""
 	Moves git folder and .gitignore to the new backup directory.
 	"""
-	if os.path.exists(os.path.join(new_path, '.git')) or os.path.exists(os.path.join(new_path, '.gitignore')):
+	new_git_dir = os.path.join(new_path, '.git')
+	new_git_ignore = os.path.join(new_path, '.gitignore')
+	if os.path.exists(new_git_dir) or os.path.exists(new_git_ignore):
 		print_red_bold("A git repo already exists here: {}".format(new_path))
 		print_red_bold("Please choose a different backup path.")
 		sys.exit()

--- a/shallow_backup/git_wrapper.py
+++ b/shallow_backup/git_wrapper.py
@@ -94,8 +94,8 @@ def move_git_repo(source_path, new_path):
 	Moves git folder and .gitignore to the new backup directory.
 	"""
 	if os.path.exists(os.path.join(new_path, '.git')) or os.path.exists(os.path.join(new_path, '.gitignore')):
-		print_red_bold("Git repository already exists new path ({})".format(new_path))
-		print_red_bold("Please choose a different directory")
+		print_red_bold("A git repo already exists here: {}".format(new_path))
+		print_red_bold("Please choose a different backup path.")
 		sys.exit()
 
 	git_dir = os.path.join(source_path, '.git')

--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -18,7 +18,7 @@ def prompt_for_path_update(config):
 	if prompt_yes_no("Would you like to update this?", Fore.GREEN):
 		print_green_bold("Enter relative or absolute path:")
 		abs_path = expand_to_abs_path(input())
-		print(Fore.BLUE + "\nUpdating shallow-backup path to {}".format(abs_path) + Style.RESET_ALL)
+		print_path_blue("\nUpdating shallow-backup path to:", abs_path)
 		mkdir_warn_overwrite(abs_path)
 		move_git_repo(current_path, abs_path)
 		config["backup_path"] = abs_path

--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -19,10 +19,10 @@ def prompt_for_path_update(config):
 		print_green_bold("Enter relative or absolute path:")
 		abs_path = expand_to_abs_path(input())
 		print(Fore.BLUE + "\nUpdating shallow-backup path to {}".format(abs_path) + Style.RESET_ALL)
-		config["backup_path"] = abs_path
-		write_config(config)
 		mkdir_warn_overwrite(abs_path)
 		move_git_repo(current_path, abs_path)
+		config["backup_path"] = abs_path
+		write_config(config)
 
 
 def prompt_for_git_url(repo):


### PR DESCRIPTION
Issue https://github.com/alichtman/shallow-backup/issues/168

Verifies if a Git repository already exists on destination path before trying to move the existing backup directory.