### PR TITLE
Exception handling

### DIFF
--- a/shallow_backup/__main__.py
+++ b/shallow_backup/__main__.py
@@ -67,7 +67,7 @@ def cli(show, all, dotfiles, configs, packages, fonts, old_path, new_path, remot
 	if new_path:
 		abs_path = os.path.abspath(new_path)
 
-		if new_dir_is_valid(abs_path):
+		if not new_dir_is_valid(abs_path):
 			sys.exit(1)
 
 		print_path_blue("\nUpdating shallow-backup path to:", abs_path)

--- a/shallow_backup/__main__.py
+++ b/shallow_backup/__main__.py
@@ -64,6 +64,10 @@ def cli(show, all, dotfiles, configs, packages, fonts, old_path, new_path, remot
 	# User entered a new path, so update the config
 	if new_path:
 		abs_path = os.path.abspath(new_path)
+		if os.path.isfile(abs_path):
+			print_path_red('New path is an existing file:', abs_path)
+			print_red_bold('Please enter a directory.')
+			sys.exit(1)
 		print_path_blue("\nUpdating shallow-backup path to:", abs_path)
 		backup_config["backup_path"] = abs_path
 		write_config(backup_config)

--- a/shallow_backup/__main__.py
+++ b/shallow_backup/__main__.py
@@ -5,7 +5,7 @@ from .reinstall import *
 from .git_wrapper import *
 from .utils import (
 	mkdir_warn_overwrite, destroy_backup_dir, expand_to_abs_path,
-	existing_file_check)
+	new_dir_is_valid)
 
 
 # custom help options
@@ -67,7 +67,7 @@ def cli(show, all, dotfiles, configs, packages, fonts, old_path, new_path, remot
 	if new_path:
 		abs_path = os.path.abspath(new_path)
 
-		if existing_file_check(abs_path):
+		if new_dir_is_valid(abs_path):
 			sys.exit(1)
 
 		print_path_blue("\nUpdating shallow-backup path to:", abs_path)

--- a/shallow_backup/__main__.py
+++ b/shallow_backup/__main__.py
@@ -3,7 +3,9 @@ from .backup import *
 from .prompts import *
 from .reinstall import *
 from .git_wrapper import *
-from .utils import mkdir_warn_overwrite, destroy_backup_dir, expand_to_abs_path
+from .utils import (
+	mkdir_warn_overwrite, destroy_backup_dir, expand_to_abs_path,
+	existing_file_check)
 
 
 # custom help options
@@ -64,10 +66,10 @@ def cli(show, all, dotfiles, configs, packages, fonts, old_path, new_path, remot
 	# User entered a new path, so update the config
 	if new_path:
 		abs_path = os.path.abspath(new_path)
-		if os.path.isfile(abs_path):
-			print_path_red('New path is an existing file:', abs_path)
-			print_red_bold('Please enter a directory.')
+
+		if existing_file_check(abs_path):
 			sys.exit(1)
+
 		print_path_blue("\nUpdating shallow-backup path to:", abs_path)
 		backup_config["backup_path"] = abs_path
 		write_config(backup_config)

--- a/shallow_backup/backup.py
+++ b/shallow_backup/backup.py
@@ -102,59 +102,53 @@ def backup_packages(backup_path, skip=False):
 		print_pkg_mgr_backup(mgr)
 		command = "{} list".format(mgr)
 		dest = "{}/{}_list.txt".format(backup_path, mgr.replace(" ", "-"))
-		run_cmd_write_stdout(command, dest)
+		run_cmd_write_stdout(command, dest, mgr)
 
 	# cargo
 	print_pkg_mgr_backup("cargo")
 	command = "ls {}".format(home_prefix(".cargo/bin/"))
 	dest = "{}/cargo_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest)
+	run_cmd_write_stdout(command, dest, 'cargo')
 
 	# pip
 	print_pkg_mgr_backup("pip")
 	command = "pip list --format=freeze"
 	dest = "{}/pip_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest)
+	run_cmd_write_stdout(command, dest, 'pip')
 
 	# npm
 	print_pkg_mgr_backup("npm")
 	command = "npm ls --global --parseable=true --depth=0"
 	temp_file_path = "{}/npm_temp_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, temp_file_path)
-	npm_dest_file = "{0}/npm_list.txt".format(backup_path)
-	# Parse npm output
-	with open(temp_file_path, mode="r+") as temp_file:
-		# Skip first line of file
-		temp_file.seek(1)
-		with open(npm_dest_file, mode="w+") as dest:
-			for line in temp_file:
-				dest.write(line.split("/")[-1])
-
-	os.remove(temp_file_path)
+	if run_cmd_write_stdout(command, temp_file_path, 'npm') == 0:
+		npm_dest_file = "{0}/npm_list.txt".format(backup_path)
+		# Parse npm output
+		with open(temp_file_path, mode="r+") as temp_file:
+			# Skip first line of file
+			temp_file.seek(1)
+			with open(npm_dest_file, mode="w+") as dest:
+				for line in temp_file:
+					dest.write(line.split("/")[-1])
+		os.remove(temp_file_path)
 
 	# atom package manager
 	print_pkg_mgr_backup("Atom")
 	command = "apm list --installed --bare"
 	dest = "{}/apm_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest)
+	run_cmd_write_stdout(command, dest, 'Atom')
 
 	# macports
 	print_pkg_mgr_backup("macports")
 	command = "port installed requested"
 	dest = "{}/macports_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest)
+	run_cmd_write_stdout(command, dest, 'macports')
 
 	# system installs
 	print_pkg_mgr_backup("System Applications")
 	applications_path = get_applications_dir()
 	command = "ls {}".format(applications_path)
 	dest = "{}/system_apps_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest)
-
-	# Clean up empty package list files
-	for file in get_abs_path_subfiles(backup_path):
-		if os.path.getsize(file) == 0:
-			os.remove(file)
+	run_cmd_write_stdout(command, dest, 'system applications')
 
 
 def backup_fonts(backup_path, skip=False):

--- a/shallow_backup/backup.py
+++ b/shallow_backup/backup.py
@@ -120,7 +120,7 @@ def backup_packages(backup_path, skip=False):
 	print_pkg_mgr_backup("npm")
 	command = "npm ls --global --parseable=true --depth=0"
 	temp_file_path = "{}/npm_temp_list.txt".format(backup_path)
-	if run_cmd_write_stdout(command, temp_file_path) == 0:
+	if not run_cmd_write_stdout(command, temp_file_path):
 		npm_dest_file = "{0}/npm_list.txt".format(backup_path)
 		# Parse npm output
 		with open(temp_file_path, mode="r+") as temp_file:

--- a/shallow_backup/backup.py
+++ b/shallow_backup/backup.py
@@ -102,25 +102,25 @@ def backup_packages(backup_path, skip=False):
 		print_pkg_mgr_backup(mgr)
 		command = "{} list".format(mgr)
 		dest = "{}/{}_list.txt".format(backup_path, mgr.replace(" ", "-"))
-		run_cmd_write_stdout(command, dest, mgr)
+		run_cmd_write_stdout(command, dest)
 
 	# cargo
 	print_pkg_mgr_backup("cargo")
 	command = "ls {}".format(home_prefix(".cargo/bin/"))
 	dest = "{}/cargo_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest, 'cargo')
+	run_cmd_write_stdout(command, dest)
 
 	# pip
 	print_pkg_mgr_backup("pip")
 	command = "pip list --format=freeze"
 	dest = "{}/pip_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest, 'pip')
+	run_cmd_write_stdout(command, dest)
 
 	# npm
 	print_pkg_mgr_backup("npm")
 	command = "npm ls --global --parseable=true --depth=0"
 	temp_file_path = "{}/npm_temp_list.txt".format(backup_path)
-	if run_cmd_write_stdout(command, temp_file_path, 'npm') == 0:
+	if run_cmd_write_stdout(command, temp_file_path) == 0:
 		npm_dest_file = "{0}/npm_list.txt".format(backup_path)
 		# Parse npm output
 		with open(temp_file_path, mode="r+") as temp_file:
@@ -135,20 +135,20 @@ def backup_packages(backup_path, skip=False):
 	print_pkg_mgr_backup("Atom")
 	command = "apm list --installed --bare"
 	dest = "{}/apm_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest, 'Atom')
+	run_cmd_write_stdout(command, dest)
 
 	# macports
 	print_pkg_mgr_backup("macports")
 	command = "port installed requested"
 	dest = "{}/macports_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest, 'macports')
+	run_cmd_write_stdout(command, dest)
 
 	# system installs
 	print_pkg_mgr_backup("System Applications")
 	applications_path = get_applications_dir()
 	command = "ls {}".format(applications_path)
 	dest = "{}/system_apps_list.txt".format(backup_path)
-	run_cmd_write_stdout(command, dest, 'system applications')
+	run_cmd_write_stdout(command, dest)
 
 
 def backup_fonts(backup_path, skip=False):

--- a/shallow_backup/git_wrapper.py
+++ b/shallow_backup/git_wrapper.py
@@ -116,3 +116,4 @@ def move_git_repo(source_path, dest_path):
 		print_blue_bold("Moving git repo to new location.")
 	except FileNotFoundError:
 		pass
+

--- a/shallow_backup/git_wrapper.py
+++ b/shallow_backup/git_wrapper.py
@@ -97,6 +97,7 @@ def move_git_repo(source_path, dest_path):
 	dest_git_ignore = os.path.join(dest_path, '.gitignore')
 	git_exists = os.path.exists(dest_git_dir)
 	gitignore_exists = os.path.exists(dest_git_ignore)
+
 	if git_exists or gitignore_exists:
 		print_red_bold("Evidence of a git repo has been detected.")
 		if git_exists:
@@ -104,7 +105,7 @@ def move_git_repo(source_path, dest_path):
 		if gitignore_exists:
 			print_path_red("A gitignore file already exists here:", dest_git_ignore)
 		print_red_bold("Exiting to prevent accidental deletion of user data.")
-		sys.exit()
+		sys.exit(1)
 
 	git_dir = os.path.join(source_path, '.git')
 	git_ignore_file = os.path.join(source_path, '.gitignore')

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -1,3 +1,4 @@
+import sys
 import inquirer
 from colorama import Fore, Style
 from .constants import ProjInfo
@@ -86,10 +87,12 @@ def print_pkg_mgr_backup(mgr):
 	print("{}Backing up {}{}{}{}{} packages list...{}".format(Fore.BLUE, Style.BRIGHT, Fore.YELLOW, mgr, Fore.BLUE,
 	                                                          Style.NORMAL, Style.RESET_ALL))
 
-
 def print_pkg_mgr_reinstall(mgr):
 	print("{}Reinstalling {}{}{}{}{}...{}".format(Fore.BLUE, Style.BRIGHT, Fore.YELLOW, mgr, Fore.BLUE, Style.NORMAL, Style.RESET_ALL))
 
+def print_pkg_mgr_error(mgr):
+	print("{}Package {}{}{}{}{} not installed.{}".format(Fore.RED, Style.BRIGHT, Fore.YELLOW, mgr, Fore.RED,
+													     Style.NORMAL, Style.RESET_ALL))
 
 def prompt_yes_no(message, color):
 	"""
@@ -102,4 +105,8 @@ def prompt_yes_no(message, color):
 	             ]
 
 	answers = inquirer.prompt(questions)
-	return answers.get('choice').strip().lower() == 'yes'
+
+	if answers:
+		return answers.get('choice').strip().lower() == 'yes'
+	else:
+		sys.exit(1)

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -87,12 +87,15 @@ def print_pkg_mgr_backup(mgr):
 	print("{}Backing up {}{}{}{}{} packages list...{}".format(Fore.BLUE, Style.BRIGHT, Fore.YELLOW, mgr, Fore.BLUE,
 	                                                          Style.NORMAL, Style.RESET_ALL))
 
+
 def print_pkg_mgr_reinstall(mgr):
 	print("{}Reinstalling {}{}{}{}{}...{}".format(Fore.BLUE, Style.BRIGHT, Fore.YELLOW, mgr, Fore.BLUE, Style.NORMAL, Style.RESET_ALL))
+
 
 def print_pkg_mgr_error(mgr):
 	print("{}Package {}{}{}{}{} not installed.{}".format(Fore.RED, Style.BRIGHT, Fore.YELLOW, mgr, Fore.RED,
 													     Style.NORMAL, Style.RESET_ALL))
+
 
 def prompt_yes_no(message, color):
 	"""
@@ -109,3 +112,4 @@ def prompt_yes_no(message, color):
 		return answers.get('choice').strip().lower() == 'yes'
 	else:
 		sys.exit(1)
+

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -94,7 +94,7 @@ def print_pkg_mgr_reinstall(mgr):
 
 
 def print_shell_cmd_error(cmd):
-	print("{}$ {}".format(print_path_red('An error occurred while running: ') cmd))
+	print("{}$ {}".format(print_path_red('An error occurred while running: '), cmd))
 
 
 def prompt_yes_no(message, color, invert=False):

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -94,7 +94,7 @@ def print_pkg_mgr_reinstall(mgr):
 
 
 def print_shell_cmd_error(cmd):
-	print("{}An error occurred while running:{} $ {}".format(Fore.RED, Style.RESET_ALL, cmd))
+	print("{}$ {}".format(print_path_red('An error occurred while running: ') cmd))
 
 
 def prompt_yes_no(message, color, invert=False):

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -105,7 +105,6 @@ def prompt_yes_no(message, color):
 	             ]
 
 	answers = inquirer.prompt(questions)
-
 	if answers:
 		return answers.get('choice').strip().lower() == 'yes'
 	else:

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -112,4 +112,3 @@ def prompt_yes_no(message, color):
 		return answers.get('choice').strip().lower() == 'yes'
 	else:
 		sys.exit(1)
-

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -93,7 +93,7 @@ def print_pkg_mgr_reinstall(mgr):
 												  mgr, Fore.BLUE, Style.NORMAL, Style.RESET_ALL))
 
 
-def print_pkg_mgr_error(cmd):
+def print_shell_cmd_error(cmd):
 	print("{}An error occurred while running:{} $ {}".format(Fore.RED, Style.RESET_ALL, cmd))
 
 
@@ -103,7 +103,7 @@ def prompt_yes_no(message, color, invert=False):
 	"""
 	questions = [inquirer.List('choice',
 	                           message=color + Style.BRIGHT + message + Fore.BLUE,
-	                           choices=(' No', ' Yes') if invert else (' Yes', ' No'),
+	                           choices=(' No', ' Yes') if invert else (' Yes', ' No')
 	                           )
 	             ]
 

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -93,10 +93,6 @@ def print_pkg_mgr_reinstall(mgr):
 												  mgr, Fore.BLUE, Style.NORMAL, Style.RESET_ALL))
 
 
-def print_shell_cmd_error(cmd):
-	print("{}$ {}".format(print_path_red('An error occurred while running: '), cmd))
-
-
 def prompt_yes_no(message, color, invert=False):
 	"""
 	Print question and return True or False depending on user selection from list.

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -101,10 +101,9 @@ def prompt_yes_no(message, color, invert=False):
 	"""
 	Print question and return True or False depending on user selection from list.
 	"""
-	choices = (' No', ' Yes') if invert else (' Yes', ' No')
 	questions = [inquirer.List('choice',
 	                           message=color + Style.BRIGHT + message + Fore.BLUE,
-	                           choices=choices,
+	                           choices=(' No', ' Yes') if invert else (' Yes', ' No'),
 	                           )
 	             ]
 

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -84,17 +84,17 @@ def print_section_header(title, color):
 
 
 def print_pkg_mgr_backup(mgr):
-	print("{}Backing up {}{}{}{}{} packages list...{}".format(Fore.BLUE, Style.BRIGHT, Fore.YELLOW, mgr, Fore.BLUE,
-	                                                          Style.NORMAL, Style.RESET_ALL))
+	print("{}Backing up {}{}{}{}{} packages list...{}".format(Fore.BLUE, Style.BRIGHT, Fore.YELLOW, mgr,
+															  Fore.BLUE, Style.NORMAL, Style.RESET_ALL))
 
 
 def print_pkg_mgr_reinstall(mgr):
-	print("{}Reinstalling {}{}{}{}{}...{}".format(Fore.BLUE, Style.BRIGHT, Fore.YELLOW, mgr, Fore.BLUE, Style.NORMAL, Style.RESET_ALL))
+	print("{}Reinstalling {}{}{}{}{}...{}".format(Fore.BLUE, Style.BRIGHT, Fore.YELLOW,
+												  mgr, Fore.BLUE, Style.NORMAL, Style.RESET_ALL))
 
 
-def print_pkg_mgr_error(mgr):
-	print("{}Package {}{}{}{}{} not installed.{}".format(Fore.RED, Style.BRIGHT, Fore.YELLOW, mgr, Fore.RED,
-													     Style.NORMAL, Style.RESET_ALL))
+def print_pkg_mgr_error(cmd):
+	print("{}An error occurred while running:{} $ {}".format(Fore.RED, Style.RESET_ALL, cmd))
 
 
 def prompt_yes_no(message, color, invert=False):

--- a/shallow_backup/printing.py
+++ b/shallow_backup/printing.py
@@ -97,13 +97,14 @@ def print_pkg_mgr_error(mgr):
 													     Style.NORMAL, Style.RESET_ALL))
 
 
-def prompt_yes_no(message, color):
+def prompt_yes_no(message, color, invert=False):
 	"""
 	Print question and return True or False depending on user selection from list.
 	"""
+	choices = (' No', ' Yes') if invert else (' Yes', ' No')
 	questions = [inquirer.List('choice',
 	                           message=color + Style.BRIGHT + message + Fore.BLUE,
-	                           choices=[' Yes', ' No'],
+	                           choices=choices,
 	                           )
 	             ]
 

--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -21,7 +21,7 @@ def path_update_prompt(config):
 			print_green_bold("Enter relative or absolute path:")
 			abs_path = expand_to_abs_path(input())
 
-			if new_dir_is_valid(abs_path):
+			if not new_dir_is_valid(abs_path):
 				continue
 
 			print_path_blue("\nUpdating shallow-backup path to:", abs_path)

--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -30,7 +30,7 @@ def path_update_prompt(config):
 			move_git_repo(current_path, abs_path)
 			config["backup_path"] = abs_path
 			write_config(config)
-			break
+			return
 
 
 def git_url_prompt(repo):

--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -6,7 +6,7 @@ from .utils import *
 from .printing import *
 from .config import *
 from .git_wrapper import git_set_remote, move_git_repo
-from .utils import existing_file_check
+from .utils import new_dir_is_valid
 
 
 def path_update_prompt(config):
@@ -21,7 +21,7 @@ def path_update_prompt(config):
 			print_green_bold("Enter relative or absolute path:")
 			abs_path = expand_to_abs_path(input())
 
-			if existing_file_check(abs_path):
+			if new_dir_is_valid(abs_path):
 				continue
 
 			print_path_blue("\nUpdating shallow-backup path to:", abs_path)

--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -6,6 +6,7 @@ from .utils import *
 from .printing import *
 from .config import *
 from .git_wrapper import git_set_remote, move_git_repo
+from .utils import existing_file_check
 
 
 def path_update_prompt(config):
@@ -20,9 +21,7 @@ def path_update_prompt(config):
 			print_green_bold("Enter relative or absolute path:")
 			abs_path = expand_to_abs_path(input())
 
-			if os.path.isfile(abs_path):
-				print_path_red('New path is an existing file:', abs_path)
-				print_red_bold('Please enter a directory.\n')
+			if existing_file_check(abs_path):
 				continue
 
 			print_path_blue("\nUpdating shallow-backup path to:", abs_path)

--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -16,7 +16,7 @@ def path_update_prompt(config):
 	"""
 	current_path = config["backup_path"]
 	print_path_blue("Current shallow-backup path:", current_path)
-	if prompt_yes_no("Would you like to update this?", Fore.GREEN):
+	if prompt_yes_no("Would you like to update this?", Fore.GREEN, invert=True):
 		while True:
 			print_green_bold("Enter relative or absolute path:")
 			abs_path = expand_to_abs_path(input())

--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import inquirer
 from colorama import Fore, Style
 from .utils import *
@@ -15,13 +16,21 @@ def path_update_prompt(config):
 	current_path = config["backup_path"]
 	print_path_blue("Current shallow-backup path:", current_path)
 	if prompt_yes_no("Would you like to update this?", Fore.GREEN):
-		print_green_bold("Enter relative or absolute path:")
-		abs_path = expand_to_abs_path(input())
-		print_path_blue("\nUpdating shallow-backup path to:", abs_path)
-		mkdir_warn_overwrite(abs_path)
-		move_git_repo(current_path, abs_path)
-		config["backup_path"] = abs_path
-		write_config(config)
+		while True:
+			print_green_bold("Enter relative or absolute path:")
+			abs_path = expand_to_abs_path(input())
+
+			if os.path.isfile(abs_path):
+				print_path_red('New path is an existing file:', abs_path)
+				print_red_bold('Please enter a directory.\n')
+				continue
+
+			print_path_blue("\nUpdating shallow-backup path to:", abs_path)
+			mkdir_warn_overwrite(abs_path)
+			move_git_repo(current_path, abs_path)
+			config["backup_path"] = abs_path
+			write_config(config)
+			break
 
 
 def git_url_prompt(repo):
@@ -159,4 +168,9 @@ def main_menu_prompt():
 	             ]
 
 	answers = inquirer.prompt(questions)
-	return answers.get('choice').strip().lower()
+
+	if answers:
+		return answers.get('choice').strip().lower()
+	else:
+		# KeyboardInterrupts
+		sys.exit(1)

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -61,8 +61,7 @@ def reinstall_packages_sb(packages_path):
 	"""
 	Reinstall all packages from the files in backup/installs.
 	"""
-	if not os.path.isdir(packages_path) or (os.path.isdir(packages_path) and 
-											not os.listdir(packages_path)):
+	if not os.path.isdir(packages_path) or not os.listdir(packages_path):
 		print_red_bold('No package backups found.')
 		sys.exit(1)
 

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -15,7 +15,7 @@ def reinstall_dots_sb(dots_path):
 	"""
 	Reinstall all dotfiles and folders by copying them to the home dir.
 	"""
-	empty_backup_dir_check(dots_path)
+	empty_backup_dir_check(dots_path, 'dotfile')
 	print_section_header("REINSTALLING DOTFILES", Fore.BLUE)
 
 	home_path = os.path.expanduser('~')
@@ -31,7 +31,7 @@ def reinstall_fonts_sb(fonts_path):
 	"""
 	Reinstall all fonts.
 	"""
-	empty_backup_dir_check(fonts_path)
+	empty_backup_dir_check(fonts_path, 'font')
 	print_section_header("REINSTALLING FONTS", Fore.BLUE)
 
 	# Copy every file in fonts_path to ~/Library/Fonts
@@ -46,7 +46,7 @@ def reinstall_configs_sb(configs_path):
 	"""
 	Reinstall all configs from the backup.
 	"""
-	empty_backup_dir_check(configs_path)
+	empty_backup_dir_check(configs_path, 'config')
 	print_section_header("REINSTALLING CONFIG FILES", Fore.BLUE)
 
 	config = get_config()
@@ -66,7 +66,7 @@ def reinstall_packages_sb(packages_path):
 	"""
 	Reinstall all packages from the files in backup/installs.
 	"""
-	empty_backup_dir_check(packages_path)
+	empty_backup_dir_check(packages_path, 'package')
 	print_section_header("REINSTALLING PACKAGES", Fore.BLUE)
 
 	# Figure out which install lists they have saved

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -61,7 +61,8 @@ def reinstall_packages_sb(packages_path):
 	"""
 	Reinstall all packages from the files in backup/installs.
 	"""
-	if not os.path.isdir(packages_path):
+	if not os.path.isdir(packages_path) or (os.path.isdir(packages_path) and 
+											not os.listdir(packages_path):
 		print_red_bold('No package backups found.')
 		sys.exit(1)
 

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -48,7 +48,7 @@ def reinstall_configs_sb(configs_path):
 		return os.path.join(configs_path, path)
 
 	config = get_config()
-	for dest_path, backup_loc in config["configs_mapping"].items():
+	for dest_path, backup_loc in config["config_mapping"].items():
 		dest_path = quote(dest_path)
 		path_to_backup = quote(backup_prefix(backup_loc))
 		# TODO: REFACTOR WITH GENERIC COPY FUNCTION.

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -1,7 +1,7 @@
 import os
 from shlex import quote
 from colorama import Fore
-from .utils import run_cmd, get_abs_path_subfiles
+from .utils import run_cmd, get_abs_path_subfiles, empty_backup_dir_check
 from .printing import *
 from .compatibility import *
 from .config import get_config
@@ -15,7 +15,9 @@ def reinstall_dots_sb(dots_path):
 	"""
 	Reinstall all dotfiles and folders by copying them to the home dir.
 	"""
+	empty_backup_dir_check(dots_path)
 	print_section_header("REINSTALLING DOTFILES", Fore.BLUE)
+
 	home_path = os.path.expanduser('~')
 	for file in get_abs_path_subfiles(dots_path):
 		if os.path.isdir(file):
@@ -29,7 +31,9 @@ def reinstall_fonts_sb(fonts_path):
 	"""
 	Reinstall all fonts.
 	"""
+	empty_backup_dir_check(fonts_path)
 	print_section_header("REINSTALLING FONTS", Fore.BLUE)
+
 	# Copy every file in fonts_path to ~/Library/Fonts
 	for font in get_abs_path_subfiles(fonts_path):
 		font_lib_path = get_fonts_dir()
@@ -42,6 +46,7 @@ def reinstall_configs_sb(configs_path):
 	"""
 	Reinstall all configs from the backup.
 	"""
+	empty_backup_dir_check(configs_path)
 	print_section_header("REINSTALLING CONFIG FILES", Fore.BLUE)
 
 	config = get_config()
@@ -61,10 +66,7 @@ def reinstall_packages_sb(packages_path):
 	"""
 	Reinstall all packages from the files in backup/installs.
 	"""
-	if not os.path.isdir(packages_path) or not os.listdir(packages_path):
-		print_red_bold('No package backups found.')
-		sys.exit(1)
-
+	empty_backup_dir_check(packages_path)
 	print_section_header("REINSTALLING PACKAGES", Fore.BLUE)
 
 	# Figure out which install lists they have saved

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -5,8 +5,6 @@ from .utils import run_cmd, get_abs_path_subfiles
 from .printing import *
 from .compatibility import *
 from .config import get_config
-from .prompts import prompt_yes_no
-from .backup import backup_packages
 from shutil import copytree, copyfile
 
 # NOTE: Naming convention is like this since the CLI flags would otherwise
@@ -65,10 +63,7 @@ def reinstall_packages_sb(packages_path):
 	"""
 	if not os.path.isdir(packages_path):
 		print_red_bold('No package backups found.')
-		if prompt_yes_no("Would you like to backup packages?", Fore.GREEN):
-			backup_packages(packages_path, skip=True)
-		else:
-			return
+		sys.exit(1)
 
 	print_section_header("REINSTALLING PACKAGES", Fore.BLUE)
 

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -5,6 +5,8 @@ from .utils import run_cmd, get_abs_path_subfiles
 from .printing import *
 from .compatibility import *
 from .config import get_config
+from .prompts import prompt_yes_no
+from .backup import backup_packages
 from shutil import copytree, copyfile
 
 # NOTE: Naming convention is like this since the CLI flags would otherwise
@@ -44,13 +46,10 @@ def reinstall_configs_sb(configs_path):
 	"""
 	print_section_header("REINSTALLING CONFIG FILES", Fore.BLUE)
 
-	def backup_prefix(path):
-		return os.path.join(configs_path, path)
-
 	config = get_config()
 	for dest_path, backup_loc in config["config_mapping"].items():
 		dest_path = quote(dest_path)
-		path_to_backup = quote(backup_prefix(backup_loc))
+		path_to_backup = quote(os.path.join(configs_path, backup_loc))
 		# TODO: REFACTOR WITH GENERIC COPY FUNCTION.
 		if os.path.isdir(path_to_backup):
 			copytree(path_to_backup, dest_path)
@@ -64,6 +63,13 @@ def reinstall_packages_sb(packages_path):
 	"""
 	Reinstall all packages from the files in backup/installs.
 	"""
+	if not os.path.isdir(packages_path):
+		print_red_bold('No package backups found.')
+		if prompt_yes_no("Would you like to backup packages?", Fore.GREEN):
+			backup_packages(packages_path, skip=True)
+		else:
+			return
+
 	print_section_header("REINSTALLING PACKAGES", Fore.BLUE)
 
 	# Figure out which install lists they have saved

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -62,7 +62,7 @@ def reinstall_packages_sb(packages_path):
 	Reinstall all packages from the files in backup/installs.
 	"""
 	if not os.path.isdir(packages_path) or (os.path.isdir(packages_path) and 
-											not os.listdir(packages_path):
+											not os.listdir(packages_path)):
 		print_red_bold('No package backups found.')
 		sys.exit(1)
 

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -78,9 +78,9 @@ def mkdir_warn_overwrite(path):
 		print_path_blue("Created directory:", path)
 
 
-def empty_backup_dir_check(backup_path):
+def empty_backup_dir_check(backup_path, backup_type):
 	if not os.path.isdir(backup_path) or not os.listdir(backup_path):
-		print_red_bold('No package backups found.')
+		print_red_bold('No package {} found.'.format(backup_type))
 		sys.exit(1)
 
 

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -32,7 +32,7 @@ def run_cmd_write_stdout(command, filepath):
 		with open(filepath, "w+") as f:
 			f.write(process.stdout.decode('utf-8'))
 	else:
-		print_path_red("An error occurred while running: $", command)  # skip package or say it's not installed?
+		print_path_red("An error occurred while running: $", command)
 		return 1
 
 

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -80,7 +80,7 @@ def mkdir_warn_overwrite(path):
 
 def empty_backup_dir_check(backup_path, backup_type):
 	if not os.path.isdir(backup_path) or not os.listdir(backup_path):
-		print_red_bold('No package {} found.'.format(backup_type))
+		print_red_bold('No {} backup found.'.format(backup_type))
 		sys.exit(1)
 
 

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -38,7 +38,7 @@ def run_cmd_write_stdout(command, filepath):
 
 def new_dir_is_valid(abs_path):
 	if os.path.isfile(abs_path):
-		print_path_red('New path is an existing file:', abs_path)
+		print_path_red('New path is a file:', abs_path)
 		print_red_bold('Please enter a directory.\n')
 		return False
 	return True

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -40,6 +40,8 @@ def new_dir_is_valid(abs_path):
 	if os.path.isfile(abs_path):
 		print_path_red('New path is an existing file:', abs_path)
 		print_red_bold('Please enter a directory.\n')
+		return False
+	return True
 
 
 def safe_mkdir(directory):

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -78,6 +78,12 @@ def mkdir_warn_overwrite(path):
 		print_path_blue("Created directory:", path)
 
 
+def empty_backup_dir_check(backup_path):
+	if not os.path.isdir(backup_path) or not os.listdir(backup_path):
+		print_red_bold('No package backups found.')
+		sys.exit(1)
+
+
 def destroy_backup_dir(backup_path):
 	"""
 	Deletes the backup directory and its content

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -34,7 +34,7 @@ def run_cmd_write_stdout(command, filepath, package):
 			f.write(process.stdout.decode('utf-8'))
 		return 0
 	else:
-		print_pkg_mgr_error(package)  # skip package or say it's not installed?
+		print_pkg_mgr_error(command)  # skip package or say it's not installed?
 		return 1
 
 

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -12,24 +12,30 @@ def run_cmd(command):
 	"""
 	try:
 		if not isinstance(command, list):
-			process = sp.run(command.split(), stdout=sp.PIPE)
+			process = sp.run(command.split(), stdout=sp.PIPE, stderr=sp.DEVNULL)
 			return process
 		else:
-			process = sp.run(command, stdout=sp.PIPE)
+			process = sp.run(command, stdout=sp.PIPE, stderr=sp.DEVNULL)
 			return process
-	except FileNotFoundError:  # If package manager is missing
+	except FileNotFoundError: # If package manager is missing 
 		return None
 
 
-def run_cmd_write_stdout(command, filepath):
+def run_cmd_write_stdout(command, filepath, package):
 	"""
 	Runs a command and then writes its stdout to a file
 	:param: command str representing command to run
+	:param: filepath str file to write command's stdout to
+	:param: package str name of package to print for failed commands
 	"""
 	process = run_cmd(command)
-	if process:
+	if process and process.returncode == 0:
 		with open(filepath, "w+") as f:
 			f.write(process.stdout.decode('utf-8'))
+		return 0
+	else:
+		print_pkg_mgr_error(package)  # skip package or say it's not installed?
+		return 1
 
 
 def safe_mkdir(directory):
@@ -47,7 +53,6 @@ def mkdir_overwrite(path):
 	if os.path.isdir(path):
 		rmtree(path)
 	os.makedirs(path)
-
 
 def mkdir_warn_overwrite(path):
 	"""

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -31,9 +31,8 @@ def run_cmd_write_stdout(command, filepath):
 	if process and process.returncode == 0:
 		with open(filepath, "w+") as f:
 			f.write(process.stdout.decode('utf-8'))
-		return 0
 	else:
-		print_pkg_mgr_error(command)  # skip package or say it's not installed?
+		print_path_red("An error occurred while running: $", command)  # skip package or say it's not installed?
 		return 1
 
 

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -60,6 +60,7 @@ def mkdir_overwrite(path):
 		rmtree(path)
 	os.makedirs(path)
 
+
 def mkdir_warn_overwrite(path):
 	"""
 	Make destination dir if path doesn't exist, confirm before overwriting if it does.

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -17,7 +17,7 @@ def run_cmd(command):
 		else:
 			process = sp.run(command, stdout=sp.PIPE, stderr=sp.DEVNULL)
 			return process
-	except FileNotFoundError: # If package manager is missing 
+	except FileNotFoundError:  # If package manager is missing
 		return None
 
 

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -38,6 +38,12 @@ def run_cmd_write_stdout(command, filepath, package):
 		return 1
 
 
+def existing_file_check(abs_path):
+	if os.path.isfile(abs_path):
+		print_path_red('New path is an existing file:', abs_path)
+		print_red_bold('Please enter a directory.\n')
+
+
 def safe_mkdir(directory):
 	"""
 	Makes directory if it doesn't already exist.

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -21,12 +21,11 @@ def run_cmd(command):
 		return None
 
 
-def run_cmd_write_stdout(command, filepath, package):
+def run_cmd_write_stdout(command, filepath):
 	"""
 	Runs a command and then writes its stdout to a file
 	:param: command str representing command to run
 	:param: filepath str file to write command's stdout to
-	:param: package str name of package to print for failed commands
 	"""
 	process = run_cmd(command)
 	if process and process.returncode == 0:


### PR DESCRIPTION
So this PR is a fix for most things that I found which could be fixed without major refactoring, including:
1. Specifying the backup path to a file (via prompt and `--new_path`).
2. KeyboardInterrupts at menus and prompts.
3. Failed but installed commands ran while backing up packages outputted error messages to STDOUT. This was the case for cargo's backup which ran `ls xxx/.cargo/bin` when I didn't have cargo.
4. There was a `configs_mapping` instead of `config_mapping` in `reinstall_configs()` when accessing the config dict.
5. Minor refactoring so that not installed packages won't get a backup directory so we don't need a for loop to clean those up.
6. Reinstalling packages without package backups errored out so now you get prompted to backup packages first.

I tried to follow your lead of allowing users to fix the issues themselves by reprompting and things like that but if you have any further suggestions I'll try my best to do them.

For some of the unfixed problems (critical and otherwise) like failing to reinstall configs for an already existing Sublime Text 3 because copytree() doesn't overwrite, I'll make a separate issue. The main reason for not fixing them in this PR was just because I didn't want to do major code revisions, I just wanted to focus on general handling in this one.