### PR TITLE
Fix IsADirectoryError upon Reinstallation

### DIFF
--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -11,14 +11,13 @@ from shutil import copytree, copyfile, copy
 #       conflict with the function names.
 
 
-def reinstall_dots_sb(dots_path):
+def reinstall_dots_sb(dots_path,home_path=os.path.expanduser("~")):
 	"""
 	Reinstall all dotfiles and folders by copying them to the home dir.
 	"""
 	empty_backup_dir_check(dots_path, 'dotfile')
 	print_section_header("REINSTALLING DOTFILES", Fore.BLUE)
 
-	home_path = os.path.expanduser('~')
 	for file in get_abs_path_subfiles(dots_path):
 		if os.path.isdir(file):
 			copytree(file, home_path, symlinks=True)

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -5,7 +5,7 @@ from .utils import run_cmd, get_abs_path_subfiles, empty_backup_dir_check
 from .printing import *
 from .compatibility import *
 from .config import get_config
-from shutil import copytree, copyfile
+from shutil import copytree, copyfile, copy
 
 # NOTE: Naming convention is like this since the CLI flags would otherwise
 #       conflict with the function names.
@@ -23,7 +23,7 @@ def reinstall_dots_sb(dots_path):
 		if os.path.isdir(file):
 			copytree(file, home_path, symlinks=True)
 		else:
-			copyfile(file, home_path)
+			copy(file, home_path)
 	print_section_header("DOTFILE REINSTALLATION COMPLETED", Fore.BLUE)
 
 

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -5,6 +5,7 @@ from .utils import run_cmd, get_abs_path_subfiles, empty_backup_dir_check
 from .printing import *
 from .compatibility import *
 from .config import get_config
+from pathlib import Path
 from shutil import copytree, copyfile, copy
 
 # NOTE: Naming convention is like this since the CLI flags would otherwise
@@ -17,12 +18,22 @@ def reinstall_dots_sb(dots_path,home_path=os.path.expanduser("~")):
 	"""
 	empty_backup_dir_check(dots_path, 'dotfile')
 	print_section_header("REINSTALLING DOTFILES", Fore.BLUE)
+	parent = Path(dots_path)
 
 	for file in get_abs_path_subfiles(dots_path):
 		if os.path.isdir(file):
 			copytree(file, home_path, symlinks=True)
 		else:
-			copy(file, home_path)
+			son=Path(os.path.dirname(file))
+			destination=""
+			if parent in son.parents:
+				folderLevel = son.relative_to(parent)
+				destination = os.path.join(home_path,folderLevel)
+				if not os.path.exists(os.path.join(home_path,folderLevel)):
+					os.makedirs(os.path.join(home_path,folderLevel))
+			else:
+				destination = home_path
+			copy(file,destination)
 	print_section_header("DOTFILE REINSTALLATION COMPLETED", Fore.BLUE)
 
 

--- a/tests/test_reinstall_dotfiles.py
+++ b/tests/test_reinstall_dotfiles.py
@@ -55,4 +55,4 @@ class TestReinstallDotfiles:
         """
         reinstall_dots_sb(DOTFILES_PATH,home_path=FAKE_HOME_DIR)
         assert os.path.isfile(os.path.join(FAKE_HOME_DIR, '.testrc'))
-        assert os.path.isdir(os.path.join(FAKE_HOME_DIR, 'testfolder/'))
+        assert os.path.isdir(os.path.join(FAKE_HOME_DIR, 'testfolder'))

--- a/tests/test_reinstall_dotfiles.py
+++ b/tests/test_reinstall_dotfiles.py
@@ -24,12 +24,19 @@ class TestReinstallDotfiles:
                 shutil.rmtree(directory)
                 os.mkdir(directory)
 
-        # SAMPLE DOTFILES FOLDER
+        # SAMPLE DOTFILES FOLDER PATH
         try:
             os.mkdir(DOTFILES_PATH)
         except FileExistsError:
             shutil.rmtree(DOTFILES_PATH)
             os.mkdir(DOTFILES_PATH)
+
+        # SAMPLE SUBFOLDER IN DOTFILES PATH
+        try:
+            os.mkdir(os.path.join(DOTFILES_PATH, "testfolder"))
+        except FileExistsError:
+            shutil.rmtree(os.path.join(DOTFILES_PATH, "testfolder"))
+            os.mkdir(os.path.join(DOTFILES_PATH, "testfolder"))
 
         # SAMPLE DOTFILE TO REINSTALL
         file = os.path.join(DOTFILES_PATH, ".testrc")
@@ -48,3 +55,4 @@ class TestReinstallDotfiles:
         """
         reinstall_dots_sb(DOTFILES_PATH,home_path=FAKE_HOME_DIR)
         assert os.path.isfile(os.path.join(FAKE_HOME_DIR, '.testrc'))
+        assert os.path.isdir(os.path.join(FAKE_HOME_DIR, 'testfolder/'))

--- a/tests/test_reinstall_dotfiles.py
+++ b/tests/test_reinstall_dotfiles.py
@@ -32,7 +32,7 @@ class TestReinstallDotfiles:
             os.mkdir(DOTFILES_PATH)
 
         # SAMPLE DOTFILE TO REINSTALL
-        file = os.path.join(DOTFILES_PATH, ".testrc"),
+        file = os.path.join(DOTFILES_PATH, ".testrc")
         print(f"Creating {file}")
         with open(file, "w+") as f:
             f.write(TEST_TEXT_CONTENT)

--- a/tests/test_reinstall_dotfiles.py
+++ b/tests/test_reinstall_dotfiles.py
@@ -32,14 +32,20 @@ class TestReinstallDotfiles:
             os.mkdir(DOTFILES_PATH)
 
         # SAMPLE SUBFOLDER IN DOTFILES PATH
+        print(os.path.join(DOTFILES_PATH, "testfolder/"))
         try:
             os.mkdir(os.path.join(DOTFILES_PATH, "testfolder/"))
         except FileExistsError:
             shutil.rmtree(os.path.join(DOTFILES_PATH, "testfolder/"))
             os.mkdir(os.path.join(DOTFILES_PATH, "testfolder/"))
 
-        # SAMPLE DOTFILE TO REINSTALL
+        # SAMPLE DOTFILES TO REINSTALL
         file = os.path.join(DOTFILES_PATH, ".testrc")
+        print(f"Creating {file}")
+        with open(file, "w+") as f:
+            f.write(TEST_TEXT_CONTENT)
+
+        file = os.path.join(DOTFILES_PATH, "testfolder/.testsubfolder_rc")
         print(f"Creating {file}")
         with open(file, "w+") as f:
             f.write(TEST_TEXT_CONTENT)
@@ -51,8 +57,10 @@ class TestReinstallDotfiles:
 
     def test_reinstall_dotfiles(self):
         """
-        Test resintalling dotfile to fake home dir
+        Test resintalling dotfiles to fake home dir
         """
         reinstall_dots_sb(DOTFILES_PATH,home_path=FAKE_HOME_DIR)
         assert os.path.isfile(os.path.join(FAKE_HOME_DIR, '.testrc'))
+        print(os.path.join(FAKE_HOME_DIR, 'testfolder/'))
         assert os.path.isdir(os.path.join(FAKE_HOME_DIR, 'testfolder/'))
+        assert os.path.isfile(os.path.join(FAKE_HOME_DIR, 'testfolder/.testsubfolder_rc'))

--- a/tests/test_reinstall_dotfiles.py
+++ b/tests/test_reinstall_dotfiles.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import shutil
+from .test_utils import FAKE_HOME_DIR, DIRS, setup_env_vars, create_config_for_test
+sys.path.insert(0, "../shallow_backup")
+from shallow_backup.reinstall import reinstall_dots_sb
+
+TEST_TEXT_CONTENT = 'THIS IS TEST CONTENT FOR THE DOTFILES'
+DOTFILES_PATH = os.path.join(FAKE_HOME_DIR, "dotfiles/")
+
+class TestReinstallDotfiles:
+    """
+    Test the functionality of reinstalling dotfiles
+    """
+
+    @staticmethod
+    def setup_method():
+        setup_env_vars()
+        create_config_for_test()
+        for directory in DIRS:
+            try:
+                os.mkdir(directory)
+            except FileExistsError:
+                shutil.rmtree(directory)
+                os.mkdir(directory)
+
+        # SAMPLE DOTFILES FOLDER
+        try:
+            os.mkdir(DOTFILES_PATH)
+        except FileExistsError:
+            shutil.rmtree(DOTFILES_PATH)
+            os.mkdir(DOTFILES_PATH)
+
+        # SAMPLE DOTFILE TO REINSTALL
+        file = os.path.join(DOTFILES_PATH, ".testrc"),
+        print(f"Creating {file}")
+        with open(file, "w+") as f:
+            f.write(TEST_TEXT_CONTENT)
+
+    @staticmethod
+    def teardown_method():
+        for directory in DIRS:
+            shutil.rmtree(directory)
+
+    def test_reinstall_dotfiles(self):
+        """
+        Test resintalling dotfile to fake home dir
+        """
+        reinstall_dots_sb(DOTFILES_PATH,home_path=FAKE_HOME_DIR)
+        assert os.path.isfile(os.path.join(FAKE_HOME_DIR, '.testrc'))

--- a/tests/test_reinstall_dotfiles.py
+++ b/tests/test_reinstall_dotfiles.py
@@ -33,10 +33,10 @@ class TestReinstallDotfiles:
 
         # SAMPLE SUBFOLDER IN DOTFILES PATH
         try:
-            os.mkdir(os.path.join(DOTFILES_PATH, "testfolder"))
+            os.mkdir(os.path.join(DOTFILES_PATH, "testfolder/"))
         except FileExistsError:
-            shutil.rmtree(os.path.join(DOTFILES_PATH, "testfolder"))
-            os.mkdir(os.path.join(DOTFILES_PATH, "testfolder"))
+            shutil.rmtree(os.path.join(DOTFILES_PATH, "testfolder/"))
+            os.mkdir(os.path.join(DOTFILES_PATH, "testfolder/"))
 
         # SAMPLE DOTFILE TO REINSTALL
         file = os.path.join(DOTFILES_PATH, ".testrc")
@@ -55,4 +55,4 @@ class TestReinstallDotfiles:
         """
         reinstall_dots_sb(DOTFILES_PATH,home_path=FAKE_HOME_DIR)
         assert os.path.isfile(os.path.join(FAKE_HOME_DIR, '.testrc'))
-        assert os.path.isdir(os.path.join(FAKE_HOME_DIR, 'testfolder'))
+        assert os.path.isdir(os.path.join(FAKE_HOME_DIR, 'testfolder/'))


### PR DESCRIPTION
So the issue is a minor one. As you were using shutil.copyfile. You are required to specify a complete path as a destination. So instead we can use shutil.copy that takes a destination as a directory as well. 

Hope this helps. Minor change hence didnt attempt the test coverage. Let me know if this works @alichtman 

Fix #216