### PR TITLE
Carefully reinstall .git and .gitignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ If you'd like to modify which files are backed up, you have to edit the `~/.conf
 1. Select the appropriate option in the CLI and follow the prompts.
 2. Open the file in a text editor and make your changes.
 
+#### .gitignore
+
+As of `v4.0`, any `.gitignore` changes should be made in the `shallow-backup` config file. `.gitignore` changes that are meant to apply to all directories should be under the `root-gitignore` key. Dotfile specific gitignores should be placed under the `dotfiles-gitignore` key. The original `default-gitignore` key in the config is still supported for backwards compatibility, however, converting to the new config format is strongly encouraged.
+
 #### Output Structure
 ---
 

--- a/shallow_backup/__main__.py
+++ b/shallow_backup/__main__.py
@@ -95,19 +95,19 @@ def cli(add_dot, all, configs, delete_config, destroy_backup, dotfiles, fonts, n
 	backup_home_path = expand_to_abs_path(get_config()["backup_path"])
 	mkdir_warn_overwrite(backup_home_path)
 	repo, new_git_repo_created = safe_git_init(backup_home_path)
+	create_gitignore(backup_home_path, "root-gitignore")
 
-	# Create default gitignore if we just ran git init
-	if new_git_repo_created:
-		safe_create_gitignore(backup_home_path)
-		# Prompt user for remote URL
-		if not remote:
-			git_url_prompt(repo)
+	# Prompt user for remote URL if needed
+	if new_git_repo_created and not remote:
+		git_url_prompt(repo)
 
 	# Set remote URL from CLI arg
 	if remote:
 		git_set_remote(repo, remote)
 
 	dotfiles_path = os.path.join(backup_home_path, "dotfiles")
+	create_gitignore(dotfiles_path, "dotfiles-gitignore")
+
 	configs_path = os.path.join(backup_home_path, "configs")
 	packages_path = os.path.join(backup_home_path, "packages")
 	fonts_path = os.path.join(backup_home_path, "fonts")

--- a/shallow_backup/config.py
+++ b/shallow_backup/config.py
@@ -64,10 +64,15 @@ def get_default_config():
 			".ssh",
 			".vim"
 		],
-		"default-gitignore": [
+		"root-gitignore": [
 			"dotfiles/.ssh",
 			"dotfiles/.pypirc",
 			".DS_Store"
+		],
+		"dotfiles-gitignore": [
+			".ssh",
+			".pypirc",
+			".DS_Store",
 		],
 		"config_mapping"   : get_config_paths()
 	}
@@ -142,18 +147,15 @@ def show_config():
 	"""
 	print_section_header("SHALLOW BACKUP CONFIG", Fore.RED)
 	for section, contents in get_config().items():
-		# Hide gitignore config
-		if section == "default-gitignore":
-			continue
 		# Print backup path on same line
-		elif section == "backup_path":
+		if section == "backup_path":
 			print_path_red("Backup Path:", contents)
 		elif section == "config_mapping":
-			print_red_bold("Configs:")
+			print_red_bold("\nConfigs:")
 			for path, dest in contents.items():
 				print("    {} -> {}".format(path, dest))
 		# Print section header and intent contents. (Dotfiles/folders)
 		else:
-			print_red_bold("\n{}: ".format(section.capitalize()))
+			print_red_bold("\n{}: ".format(section.replace("-", " ").capitalize()))
 			for item in contents:
 				print("    {}".format(item))

--- a/shallow_backup/constants.py
+++ b/shallow_backup/constants.py
@@ -1,6 +1,6 @@
 class ProjInfo:
 	PROJECT_NAME = 'shallow-backup'
-	VERSION = '3.4'
+	VERSION = '4.0'
 	AUTHOR_GITHUB = 'alichtman'
 	AUTHOR_FULL_NAME = 'Aaron Lichtman'
 	DESCRIPTION = "Easily create lightweight backups of installed packages, dotfiles, and more."

--- a/shallow_backup/utils.py
+++ b/shallow_backup/utils.py
@@ -129,14 +129,19 @@ def destroy_backup_dir(backup_path):
 
 def get_abs_path_subfiles(directory):
 	"""
-	Returns list of absolute paths of files and folders contained in a directory, excluding .git directories.
+	Returns list of absolute paths of files and folders contained in a directory,
+	excluding the root .git directory and root .gitignore..
 	"""
 	file_paths = []
 	for path, _, files in os.walk(directory):
 		for name in files:
 			joined = os.path.join(path, name)
-			if "/.git/" not in joined:
-				file_paths.append(os.path.join(path, name))
+			root_git_dir = os.path.join(directory, ".git")
+			root_gitignore = os.path.join(directory, ".gitignore")
+			if root_git_dir not in joined and root_gitignore not in joined:
+				file_paths.append(joined)
+			else:
+			    print(f"Excluded: {joined}")
 	return file_paths
 
 

--- a/tests/test_git_folder_moving.py
+++ b/tests/test_git_folder_moving.py
@@ -3,7 +3,7 @@ import sys
 import shutil
 from .test_utils import BACKUP_DEST_DIR, FAKE_HOME_DIR, DIRS, setup_env_vars, create_config_for_test
 sys.path.insert(0, "../shallow_backup")
-from shallow_backup.git_wrapper import move_git_repo, safe_git_init, safe_create_gitignore
+from shallow_backup.git_wrapper import move_git_repo, safe_git_init, create_gitignore
 
 
 class TestGitFolderCopying:
@@ -32,7 +32,7 @@ class TestGitFolderCopying:
         Test copying the .git folder and .gitignore from an old directory to a new one
         """
         safe_git_init(FAKE_HOME_DIR)
-        safe_create_gitignore(FAKE_HOME_DIR)
+        create_gitignore(FAKE_HOME_DIR, "root-gitignore")
         move_git_repo(FAKE_HOME_DIR, BACKUP_DEST_DIR)
         assert os.path.isdir(os.path.join(BACKUP_DEST_DIR, '.git/'))
         assert os.path.isfile(os.path.join(BACKUP_DEST_DIR, '.gitignore'))


### PR DESCRIPTION
- Add root-gitignore and dotfiles-gitignore keys to
config to replace default-gitignore.
- Move all gitignore functionality to config.
- Add tests for new .git-related operations
- Bump version to v4.0