### PR TITLE
Allow setting backup path to ~/.shallow-backup

### DIFF
--- a/shallow_backup/upgrade.py
+++ b/shallow_backup/upgrade.py
@@ -41,9 +41,6 @@ def upgrade_from_pre_v3():
 			else:
 				print_red_bold("Please downgrade to a version of shallow-backup before v3.0 if you do not want to upgrade your config.")
 				sys.exit()
-		elif os.path.isdir(old_config_path):
-			print_red_bold(f"ERROR: {old_config_path} is a directory, when we were expecting a file. Manual intervention is required.")
-			sys.exit(1)
 
 	# Clean up ~/.config/shallow-backup
 	incorrect_config_dir = os.path.join(get_xdg_config_path(), "shallow-backup")


### PR DESCRIPTION
Closes #265.

If `~/.shallow-backup` resolves to a directory, then it can't be a config file to migrate. Tests pass (although I don't think there's an "upgrade" test) and manual testing appears to work as expected.

btw, thanks for this handy program :)