### PR TITLE
Be clear that changing backup path moves the folder

### DIFF
--- a/shallow_backup/prompts.py
+++ b/shallow_backup/prompts.py
@@ -16,7 +16,7 @@ def path_update_prompt(config):
 	"""
 	current_path = config["backup_path"]
 	print_path_blue("Current shallow-backup path:", current_path)
-	if prompt_yes_no("Would you like to update this?", Fore.GREEN, invert=True):
+	if prompt_yes_no("Would you like to move this somewhere else?", Fore.GREEN, invert=True):
 		while True:
 			print_green_bold("Enter relative or absolute path:")
 			abs_path = expand_to_abs_path(input())


### PR DESCRIPTION
Closes #266.

I went the simple route of just changing the name of the action from "update [the backup path]" to "move [the backup path] somewhere else". This is as clear as I could get it while remaining terse enough for a one-line prompt.