### PR TITLE
Enable resolution of variables in config paths

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 - [Peter Yasi](https://github.com/pyasi)
 - [Nicole Tibay](https://github.com/neequole)
 - [Rods](https://github.com/rods-honorio)
+- [Jerome Brown](https://github.com/oWretch)

--- a/shallow_backup/backup.py
+++ b/shallow_backup/backup.py
@@ -114,12 +114,13 @@ def backup_configs(backup_path, dry_run: bool = False, skip=False):
 			continue
 
 		quoted_dest = quote(dest)
-		if os.path.isdir(config_path):
-			copytree(config_path, quoted_dest, symlinks=True)
-		elif os.path.isfile(config_path):
+		expanded_path = os.path.expandvars(os.path.expanduser(config_path))
+		if os.path.isdir(expanded_path):
+			copytree(expanded_path, quoted_dest, symlinks=True)
+		elif os.path.isfile(expanded_path):
 			parent_dir = Path(dest).parent
 			safe_mkdir(parent_dir)
-			copyfile(config_path, quoted_dest)
+			copyfile(expanded_path, quoted_dest)
 
 
 def backup_packages(backup_path, dry_run: bool = False, skip=False):


### PR DESCRIPTION
I have a desire to sync my configuration between machines where my username is different on each. Currently, the config backup just uses the raw path provided in the configuration file and doesn't attempt to resolve any variables from within the path.

This PR updates the config backup process to resolve variables in the config path string, such as `~` and `$HOME` and thereby allow one config to be used across different machines.

The upshot of this change is it would be possible for someone to perform advanced backup and restore by setting environment variables to move files around between machines.