### PR TITLE
 Deprecate apm backups and restores

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ By default, `shallow-backup` backs these up.
     * Terminal.app
 
 3. Installed Packages
-    * `apm`
     * `brew` and `cask`
     * `cargo`
     * `gem`
@@ -266,7 +265,6 @@ backup_dir/
 │   ├── Ubuntu Mono derivative Powerline Italic.ttf
 │   └── Ubuntu Mono derivative Powerline.ttf
 └── packages
-    ├── apm_list.txt
     ├── brew-cask_list.txt
     ├── brew_list.txt
     ├── cargo_list.txt

--- a/shallow_backup/backup.py
+++ b/shallow_backup/backup.py
@@ -186,12 +186,6 @@ def backup_packages(backup_path, dry_run: bool = False, skip=False):
 					[dest.write(f"{package}\n") for package in npm_packages]
 		os.remove(temp_file_path)
 
-	# atom package manager
-	print_pkg_mgr_backup("Atom")
-	command = "apm list --installed --bare"
-	dest = f"{backup_path}/apm_list.txt"
-	run_cmd_if_no_dry_run(command, dest, dry_run)
-
 	# vscode extensions
 	print_pkg_mgr_backup("VSCode")
 	command = "code --list-extensions --show-versions"

--- a/shallow_backup/reinstall.py
+++ b/shallow_backup/reinstall.py
@@ -124,7 +124,7 @@ def reinstall_packages_sb(packages_path: str, dry_run: bool = False):
 	package_mgrs = set()
 	for file in os.listdir(packages_path):
 		manager = file.split("_")[0].replace("-", " ")
-		if manager in ["gem", "cargo", "npm", "pip", "pip3", "brew", "vscode", "apm", "macports"]:
+		if manager in ["gem", "cargo", "npm", "pip", "pip3", "brew", "vscode", "macports"]:
 			package_mgrs.add(file.split("_")[0])
 
 	print_blue_bold("Package Manager Backups Found:")
@@ -157,10 +157,6 @@ def reinstall_packages_sb(packages_path: str, dry_run: bool = False):
 				for package in file:
 					cmd = f"code --install-extension {package}"
 					run_cmd_if_no_dry_run(cmd, dry_run)
-		elif pm == "apm":
-			print_pkg_mgr_reinstall(pm)
-			cmd = f"apm install --packages-file {packages_path}/apm_list.txt"
-			run_cmd_if_no_dry_run(cmd, dry_run)
 		elif pm == "macports":
 			print_red_bold("WARNING: Macports reinstallation is not supported.")
 		elif pm == "gem":


### PR DESCRIPTION
https://github.com/atom/atom has been deprecated. shallow-backup will no longer support it. RIP my old friend.